### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,11 @@ Pre-Flight Instructions
 * For certificate chains: cat all the certs together
 
     cat cert.der server-chain2.der server-chain1.der ct_root.der > certs.der
+    
+or export them into .p7b
+
+    openssl crl2pkcs7 -nocrl -certfile fullchain.pem -out certs.p7b
+    
 
 * Build ImportKey
 


### PR DESCRIPTION
According to my discussion on https://serverfault.com/questions/871543/openssl-certificate-chain-lost-when-converting-from-pem-to-der
there's a simpler way of importing certificate chains.